### PR TITLE
fix(routes): protect from invalid routes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,7 @@ import About from "./components/About/About";
 import Projects from "./components/Projects/Projects";
 import Footer from "./components/Footer";
 import Resume from "./components/Resume/ResumeNew";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { BrowserRouter as Router, Route, Switch, Redirect } from "react-router-dom";
 import "./style.css";
 import "./App.css";
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -32,9 +32,10 @@ function App() {
         <ScrollToTop />
         <Switch>
           <Route path="/" exact component={Home} />
-          <Route path="/project" component={Projects} />
-          <Route path="/about" component={About} />
-          <Route path="/resume" component={Resume} />
+          <Route path="/project" exact component={Projects} />
+          <Route path="/about" exact component={About} />
+          <Route path="/resume" exact component={Resume} />
+          <Redirect to="/" />
         </Switch>
         <Footer />
       </div>


### PR DESCRIPTION
The commit message is self-explanatory:

* I added a `Redirect` among the routes to prevent rendering of meaningless pages in case of wrong URLs, e.g.  `<BASE_URL>/foo` displayed an empty page with the navbar and the footer, which, I think, is not what you expect [see the bug [here](http://soumya-jit.tech/foo)]
 
* I forced paths to be exact to prevent "partially correct" routes like `BASE_URL/about/bar` to render the `About` page [see the bug [here](http://soumya-jit.tech/about/bar)]. Now it doesn't match anymore and falls into the `Redirect` component.

This solves the issue #46 .