### PR TITLE
Fixed social media buttons being rendered behind tspartical div

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -412,6 +412,7 @@ button:focus {
 }
 
 .footer-body {
+  z-index: 1;
   text-align: center !important;
 }
 


### PR DESCRIPTION
Added a z-index property to the social media button div to make it render over the tsparticles div, allowing the buttons to be clicked on the About and Projects page.