### PR TITLE
Add External Links to Toolstack Icons

### DIFF
--- a/src/components/About/Toolstack.js
+++ b/src/components/About/Toolstack.js
@@ -1,3 +1,37 @@
+// import React from "react";
+// import { Col, Row } from "react-bootstrap";
+// import {
+//   SiVisualstudiocode,
+//   SiPostman,
+//   SiSlack,
+//   SiVercel,
+//   SiMacos,
+// } from "react-icons/si";
+
+// function Toolstack() {
+//   return (
+//     <Row style={{ justifyContent: "center", paddingBottom: "50px" }}>
+//       <Col xs={4} md={2} className="tech-icons">
+//         <SiMacos />
+//       </Col>
+//       <Col xs={4} md={2} className="tech-icons">
+//         <SiVisualstudiocode />
+//       </Col>
+//       <Col xs={4} md={2} className="tech-icons">
+//         <SiPostman />
+//       </Col>
+//       <Col xs={4} md={2} className="tech-icons">
+//         <SiSlack />
+//       </Col>
+//       <Col xs={4} md={2} className="tech-icons">
+//         <SiVercel />
+//       </Col>
+//     </Row>
+//   );
+// }
+
+// export default Toolstack;
+
 import React from "react";
 import { Col, Row } from "react-bootstrap";
 import {
@@ -9,21 +43,26 @@ import {
 } from "react-icons/si";
 
 function Toolstack() {
+  // Function to open link in a new tab
+  const openInNewTab = (url) => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  };
+
   return (
     <Row style={{ justifyContent: "center", paddingBottom: "50px" }}>
-      <Col xs={4} md={2} className="tech-icons">
+      <Col xs={4} md={2} className="tech-icons" onClick={() => openInNewTab("https://www.apple.com/macos/")}>
         <SiMacos />
       </Col>
-      <Col xs={4} md={2} className="tech-icons">
+      <Col xs={4} md={2} className="tech-icons" onClick={() => openInNewTab("https://code.visualstudio.com/")}>
         <SiVisualstudiocode />
       </Col>
-      <Col xs={4} md={2} className="tech-icons">
+      <Col xs={4} md={2} className="tech-icons" onClick={() => openInNewTab("https://www.postman.com/")}>
         <SiPostman />
       </Col>
-      <Col xs={4} md={2} className="tech-icons">
+      <Col xs={4} md={2} className="tech-icons" onClick={() => openInNewTab("https://slack.com/")}>
         <SiSlack />
       </Col>
-      <Col xs={4} md={2} className="tech-icons">
+      <Col xs={4} md={2} className="tech-icons" onClick={() => openInNewTab("https://vercel.com/")}>
         <SiVercel />
       </Col>
     </Row>
@@ -31,3 +70,4 @@ function Toolstack() {
 }
 
 export default Toolstack;
+


### PR DESCRIPTION
**This PR enhances the Toolstack component by adding clickable icons that open external websites for each tool in a new tab, avoiding page refresh and maintaining the React app's state. Instead of <a> tags, an onClick handler with window.open() is used to keep the navigation seamless.**

### Changes:

1. Added openInNewTab function to handle external links using window.open().
2. Updated each icon in Toolstack to include an onClick event, linking to the official site of the tool.
3. Ensured the app's routing and state are unaffected by external link clicks.
4. Testing:

**Verified that each icon opens the correct website in a new tab without reloading or affecting the app's state**